### PR TITLE
Call tag_builder.tag_options

### DIFF
--- a/lib/rails_rinku.rb
+++ b/lib/rails_rinku.rb
@@ -16,7 +16,7 @@ module RailsRinku
     Rinku.auto_link(
       text,
       options[:link],
-      tag_options(options[:html]),
+      tag_builder.tag_options(options[:html]),
       options[:skip],
       &block
     ).html_safe


### PR DESCRIPTION
in vmg/rinku this is done conditionally for Rails 5.1. Since Rails 5.1 is EOL, We can likely always call tag_builder.tag_options now.

Does this work for you all? I am happy to update it to be conditional to match vmg if you prefer.